### PR TITLE
Add functionality of specifying specific file to load data from.

### DIFF
--- a/data/newdata.txt
+++ b/data/newdata.txt
@@ -1,0 +1,4 @@
+D , 1 , I need to do this , Jun 9 2023
+E , 0 , I need to do this , Jun 11 2023
+T , 0 , do this
+T , 1 , i have added this new task

--- a/src/main/java/betago/Duke.java
+++ b/src/main/java/betago/Duke.java
@@ -26,7 +26,7 @@ public class Duke {
         this.storage = new Storage(this.tasks);
         this.commander = new Parser(this.tasks, this.storage);
         Ui.greet();
-        this.storage.loadFile();
+        this.storage.loadDefaultFile();
     }
     /**
      * Returns a response to the user's input by calling the appropriate command

--- a/src/main/java/betago/Parser.java
+++ b/src/main/java/betago/Parser.java
@@ -9,6 +9,7 @@ import betago.commands.DeleteCommand;
 import betago.commands.FindCommand;
 import betago.commands.InvalidCommand;
 import betago.commands.ListCommand;
+import betago.commands.LoadCommand;
 import betago.commands.MarkUnmarkCommand;
 
 /**
@@ -49,6 +50,8 @@ public class Parser {
             return new DeleteCommand();
         } else if (inputs[0].equalsIgnoreCase("find")) {
             return new FindCommand();
+        } else if (inputs[0].equalsIgnoreCase("load")) {
+            return new LoadCommand();
         } else if (input.equalsIgnoreCase("bye")) {
             return new ByeCommand();
         } else {

--- a/src/main/java/betago/Storage.java
+++ b/src/main/java/betago/Storage.java
@@ -13,6 +13,7 @@ import betago.tasks.Task;
  */
 public class Storage {
     private final TaskList tasks;
+    private String fileName;
 
     /**
      * Constructor for Storage.
@@ -25,13 +26,14 @@ public class Storage {
     /**
      * Checks if data/duke.txt file exists.
      * If it exists, calls the convertFile method accordingly to read file.
-     * Else, create an empty data/duke.txt file.
+     * Else, create an empty duke.txt file.
      * Errors in creating the file or invalid text in the data file will print errors accordingly.
      */
-    public void loadFile() {
+    public void loadDefaultFile() {
         try {
             File dir = new File("data");
             File f = new File("data/duke.txt");
+            this.fileName = "data/duke.txt";
             if (!dir.exists()) {
                 dir.mkdir();
                 f.createNewFile();
@@ -66,18 +68,46 @@ public class Storage {
             } else if (str.charAt(0) == 'E') {
                 this.tasks.loadEvent(str);
             } else {
-                Ui.printLoadFileError();
+                throw new DukeException("The data in the file is invalid and cannot be read.");
             }
         }
         sc1.close();
     }
 
     /**
+     * Checks if specific file exists.
+     * If it exists, calls the convertFile method accordingly to read file.
+     * @param str Input from the user containing load command and filename.
+     * @throws DukeException If file does not exist, is not a .txt file or contains invalid entries.
+     */
+    public String loadNewFile(String str) throws DukeException {
+        String[] inputs = str.split(" ", 2);
+        if (inputs.length != 2) {
+            throw new DukeException("Please enter the file that you want to load in the format: 'load (filename)'");
+        }
+        try {
+            String pathName = "data/" + inputs[1];
+            File f = new File(pathName);
+            if (!f.exists()) {
+                throw new DukeException("Apologies Human. The specific file does not exist!\n"
+                        + "Do ensure the specific file is stored in the data folder.");
+            } else if (!pathName.toLowerCase().endsWith(".txt")) {
+                throw new DukeException("Please ensure the data file to be loaded is a .txt file!");
+            }
+            this.tasks.refreshList(); // Current implementation clears list even if there are invalid entries!
+            convertFile(f);
+            this.fileName = pathName;
+            return "The data in " + pathName + " has been successfully loaded!";
+        } catch (FileNotFoundException e) {
+            throw new DukeException("Error in finding specific file.");
+        }
+    }
+    /**
      * Saves tasks in TaskList into data/duke.txt file.
      */
     public void saveItems() {
         try {
-            FileWriter fw = new FileWriter("data/duke.txt", false);
+            FileWriter fw = new FileWriter(this.fileName, false);
             for (int i = 0; i < this.tasks.getSize(); i++) {
                 Task temp = this.tasks.get(i);
                 fw.write(temp.saveTask());

--- a/src/main/java/betago/TaskList.java
+++ b/src/main/java/betago/TaskList.java
@@ -42,7 +42,12 @@ public class TaskList {
     public int getSize() {
         return this.list.size();
     }
-
+    /**
+     * Clears the current list.
+     */
+    public void refreshList() {
+        this.list.clear();
+    }
     /**
      * Returns the list of Tasks in the current TaskList.
      *

--- a/src/main/java/betago/commands/LoadCommand.java
+++ b/src/main/java/betago/commands/LoadCommand.java
@@ -1,0 +1,27 @@
+package betago.commands;
+
+import betago.DukeException;
+import betago.Storage;
+import betago.TaskList;
+
+/**
+ * LoadCommand class that loads data from specific file.
+ */
+public class LoadCommand implements Command {
+    /**
+     * Returns a list of the current tasks in the tasklist.
+     *
+     * @param tasks Tasklist that stores the various tasks.
+     * @param storage Storage to load and save files.
+     * @param str Input from the user.
+     * @return Output to the user after executing the command.
+     */
+    @Override
+    public String execute(TaskList tasks, Storage storage, String str) {
+        try {
+            return storage.loadNewFile(str);
+        } catch (DukeException e) {
+            return e.getMessage();
+        }
+    }
+}


### PR DESCRIPTION
Current data is always pulled and saved from duke.txt file.

Allowing users to specify the file they want to load and save data in allows them to personalise multiple tasklists and adds more personalisation.

Let's,
- Make default file load and save into duke.txt file
- Allow users to call a new load command to specify the file they want to load
- After successful load, auto-save will occur into the new file instead of duke.txt file

However, current implementation clears tasklist when loading data even when file is not able to load due to invalid entries which may cause data to be lost.